### PR TITLE
Update Readme.md to add pkg-config to linux apt

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The prebuilt image and document are here:
 ## Linux
 - git clone https://github.com/NXPmicro/mfgtools.git
 - cd mfgtools
-- sudo apt-get install libusb-1.0.0-dev libzip-dev libbz2-dev
+- sudo apt-get install libusb-1.0.0-dev libzip-dev libbz2-dev pkg-config
 - cmake .
 - make
 


### PR DESCRIPTION
Under Debian 9 (stretch) pkg-config is needed for the build. Added to the apt-get install line.